### PR TITLE
added epoch timsstamp (millisecond) support for kibana on ex-div snap

### DIFF
--- a/manual_logstash_load.config
+++ b/manual_logstash_load.config
@@ -12,7 +12,7 @@ filter {
 
 			skip_header => true
 			# going to try and specify column names that align with index in elastic
-			columns => ["symbol", "company", "yield_snap", "ex_div_date_snap", "exchange"]
+			columns => ["symbol", "company", "yield_snap", "ex_div_date_snap", "exchange", "ex_div_date_snap_epoch"]
 			# custom type field - ticker doc_type
 			add_field => {
 						"doc_type"=>"ticker"

--- a/stonks_utils.py
+++ b/stonks_utils.py
@@ -121,6 +121,7 @@ def getTickers(in_file_path):
         sys.exit(1)
     df = dfs[0]
     df['Exchange'] = "TSX"
+    df['ex-div epoch'] = df.apply (lambda x: int(((datetime.datetime.strptime(x['Next Ex-div Date'], "%Y-%m-%d")).timestamp())*1000), axis=1)
     df.to_csv(f'{data_file_path}DH_tickers_tsx.csv')
     
     try:
@@ -130,6 +131,7 @@ def getTickers(in_file_path):
         sys.exit(1)
     df = dfs[0]
     df['Exchange'] = "NYSE"
+    df['ex-div epoch'] = df.apply (lambda x: int(((datetime.datetime.strptime(x['Next Ex-div Date'], "%Y-%m-%d")).timestamp())*1000), axis=1)
     df.to_csv(f'{data_file_path}DH_tickers_nyse.csv')
     
     try:
@@ -139,6 +141,7 @@ def getTickers(in_file_path):
         sys.exit(1)
     df = dfs[0]
     df['Exchange'] = "NASDAQ"
+    df['ex-div epoch'] = df.apply (lambda x: int(((datetime.datetime.strptime(x['Next Ex-div Date'], "%Y-%m-%d")).timestamp())*1000), axis=1)
     df.to_csv(f'{data_file_path}DH_tickers_nasdaq.csv')
 
 
@@ -212,6 +215,13 @@ def all_fridays_from(in_year: int):
                     if x<current_date:
                         fridays.append(x)
     return fridays
+
+
+# assumes a date format YYYY-MM-DD 
+def str_date_to_epoch(in_date_str):
+    date_epoch = datetime.datetime.strptime(in_date_str, "%Y-%m-%d")
+    return date_epoch.timestamp()
+
 
 def make_dir(path):
     if not os.path.exists(path):


### PR DESCRIPTION
Added in support for epoch timestamp generation based on ex-div snapshot field.  This is to allow kibana to appropriately process the dates for future visualizations.  